### PR TITLE
- photo de la plante du slider à remplacer

### DIFF
--- a/home/migrations/0005_auto_20170406_1131.py
+++ b/home/migrations/0005_auto_20170406_1131.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailforms', '0003_capitalizeverbose'),
-        ('wagtailcore', '0033_auto_20170323_0108'),
+        ('wagtailcore', '0019_verbose_names_cleanup'),
         ('wagtailredirects', '0005_capitalizeverbose'),
         ('home', '0004_auto_20170331_1309'),
     ]


### PR DESCRIPTION
- Animation du logo et taille à diminuer

- Qui somme nous avec s et point d d'interrogation à la fin.

- evenements a faire défiler

- page home s'arrête à qui somme nous

- image de l'empreinte digital à changer

- notre vision / mission à dissocier et les déplacer dans la page A propos + image à refaire (vision/ mission)

- changer le texte des objectifs selon la plaquette WAFA

- déplacer la liste des Membres du bureau dans la page Membre

- enlever les drapeaux des pays Membre et mettre logo ecowas et carte de l'Afrique de l'ouest à centrer et à déplacer dans la page Membres.

- cacher la liste des membres ( en attendant leur accord ) et retenir comme information nom de la société / pays / activité

- Supprimer la page produits

- Les éléments WAFBIM et FERWAM à considérer dans Publications

-  Préciser la date de fin et supprimer l'heure des événements